### PR TITLE
feat(chargers): add public GET /api/chargers with pagination and filt…

### DIFF
--- a/apps/backend/src/app/api/chargers/route.ts
+++ b/apps/backend/src/app/api/chargers/route.ts
@@ -1,10 +1,17 @@
+// apps/backend/src/app/api/chargers/route.ts
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/db";
 import { ok, options } from "@/lib/http";
+import type { Prisma, ConnectorType } from "@/generated/prisma"; // <- matches your generator output
+
+// Type guard to keep TS happy and avoid `any`
+function isConnectorType(v: string): v is ConnectorType {
+  return (Object.values(ConnectorType) as string[]).includes(v);
+}
 
 // CORS preflight
-export function OPTIONS() { 
-  return options(); 
+export function OPTIONS() {
+  return options();
 }
 
 // Public list of ALL chargers (paginated, newest first)
@@ -15,13 +22,17 @@ export async function GET(req: NextRequest) {
   const pageSize = Math.min(Math.max(1, Number(url.searchParams.get("pageSize") ?? "20")), 100);
 
   // Optional simple filters
-  const connector = url.searchParams.get("connector");     // e.g. TYPE2
-  const available = url.searchParams.get("available");     // "true"/"false"
+  const connectorParam = url.searchParams.get("connector"); // e.g. TYPE2
+  const availableParam = url.searchParams.get("available"); // "true" | "false" | null
 
-  const where: any = {};
-  if (connector) where.connector = connector as any;
-  if (available === "true")  where.available = true;
-  if (available === "false") where.available = false;
+  const where: Prisma.ChargerWhereInput = {};
+
+  if (connectorParam && isConnectorType(connectorParam)) {
+    where.connector = connectorParam; // typed as ConnectorType
+  }
+
+  if (availableParam === "true") where.available = true;
+  if (availableParam === "false") where.available = false;
 
   const [items, total] = await Promise.all([
     prisma.charger.findMany({

--- a/apps/backend/src/app/api/chargers/route.ts
+++ b/apps/backend/src/app/api/chargers/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/db";
+import { ok, options } from "@/lib/http";
+
+// CORS preflight
+export function OPTIONS() { 
+  return options(); 
+}
+
+// Public list of ALL chargers (paginated, newest first)
+export async function GET(req: NextRequest) {
+  const url = new URL(req.url);
+
+  const page = Math.max(1, Number(url.searchParams.get("page") ?? "1"));
+  const pageSize = Math.min(Math.max(1, Number(url.searchParams.get("pageSize") ?? "20")), 100);
+
+  // Optional simple filters
+  const connector = url.searchParams.get("connector");     // e.g. TYPE2
+  const available = url.searchParams.get("available");     // "true"/"false"
+
+  const where: any = {};
+  if (connector) where.connector = connector as any;
+  if (available === "true")  where.available = true;
+  if (available === "false") where.available = false;
+
+  const [items, total] = await Promise.all([
+    prisma.charger.findMany({
+      where,
+      orderBy: { createdAt: "desc" },
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+    }),
+    prisma.charger.count({ where }),
+  ]);
+
+  return ok({ items, page, pageSize, total });
+}


### PR DESCRIPTION
# ✨ Public Chargers Listing

## Overview
Adds a **public** endpoint to list chargers for driver discovery.

## Endpoint
- **GET** `/api/chargers`
  - Supports pagination: `page`, `pageSize`
  - Optional filters:
    - `connector` (e.g., `TYPE2`, `CCS2`, `CHADEMO`, `CCS1`, `NEMA14_50`, `SCHUKO`)
    - `available` (`true` | `false`)
  - (Optional if enabled) Map bounding box: `minLat`, `minLng`, `maxLat`, `maxLng`

## Notes
- No authentication required (read-only).
- CORS headers included for SPA at `http://localhost:5173`.

## Testing
```bash
curl -i "http://localhost:3000/api/chargers?page=1&pageSize=10"
# Show only available chargers
curl -i "http://localhost:3000/api/chargers?connector=TYPE2&available=true"
# Filter by connector type (e.g., TYPE2)
curl -i "http://localhost:3000/api/chargers?connector=TYPE2"
