### PR TITLE
Darko/charger session

### DIFF
--- a/apps/backend/SESSION_API_EXAMPLES.md
+++ b/apps/backend/SESSION_API_EXAMPLES.md
@@ -1,0 +1,37 @@
+# Sessions API — cURL Examples
+
+## Start a session (driver)
+```bash
+curl -X POST "http://localhost:3000/api/chargers/<CHARGER_ID>/start" \
+  -H "Authorization: Bearer <JWT>"
+```
+
+## Stop a session (driver)
+```bash
+curl -X POST "http://localhost:3000/api/sessions/<SESSION_ID>/stop" \
+  -H "Authorization: Bearer <JWT>"
+```
+
+## List my sessions (driver)
+```bash
+curl "http://localhost:3000/api/sessions?page=1&pageSize=10" \
+  -H "Authorization: Bearer <JWT>"
+```
+
+## List sessions on my chargers (host)
+```bash
+curl "http://localhost:3000/api/sessions?scope=host&page=1&pageSize=10" \
+  -H "Authorization: Bearer <JWT>"
+```
+
+## Get one session (driver)
+```bash
+curl "http://localhost:3000/api/sessions/<SESSION_ID>" \
+  -H "Authorization: Bearer <JWT>"
+```
+
+## Get one session (host)
+```bash
+curl "http://localhost:3000/api/sessions/<SESSION_ID>?scope=host" \
+  -H "Authorization: Bearer <JWT>"
+```

--- a/apps/backend/prisma/migrations/20251013114132_add_charging_session/migration.sql
+++ b/apps/backend/prisma/migrations/20251013114132_add_charging_session/migration.sql
@@ -1,0 +1,48 @@
+-- CreateEnum
+CREATE TYPE "ChargingStatus" AS ENUM ('PENDING', 'ACTIVE', 'STOPPED', 'SETTLED', 'CANCELLED');
+
+-- AlterTable
+ALTER TABLE "Charger" ADD COLUMN     "powerKw" DOUBLE PRECISION NOT NULL DEFAULT 22;
+
+-- CreateTable
+CREATE TABLE "ChargingSession" (
+    "id" TEXT NOT NULL,
+    "driverId" TEXT NOT NULL,
+    "chargerId" TEXT NOT NULL,
+    "hostId" TEXT NOT NULL,
+    "status" "ChargingStatus" NOT NULL DEFAULT 'PENDING',
+    "pricePerKwhSnapshot" DOUBLE PRECISION NOT NULL,
+    "powerKwSnapshot" DOUBLE PRECISION NOT NULL,
+    "connectorSnapshot" "ConnectorType" NOT NULL,
+    "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "stoppedAt" TIMESTAMP(3),
+    "energyKwh" DOUBLE PRECISION,
+    "costTotal" DOUBLE PRECISION,
+    "startTxSig" TEXT,
+    "stopTxSig" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ChargingSession_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ChargingSession_driverId_status_idx" ON "ChargingSession"("driverId", "status");
+
+-- CreateIndex
+CREATE INDEX "ChargingSession_chargerId_status_idx" ON "ChargingSession"("chargerId", "status");
+
+-- CreateIndex
+CREATE INDEX "ChargingSession_hostId_status_idx" ON "ChargingSession"("hostId", "status");
+
+-- CreateIndex
+CREATE INDEX "Charger_hostId_idx" ON "Charger"("hostId");
+
+-- AddForeignKey
+ALTER TABLE "ChargingSession" ADD CONSTRAINT "ChargingSession_driverId_fkey" FOREIGN KEY ("driverId") REFERENCES "DriverProfile"("userId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ChargingSession" ADD CONSTRAINT "ChargingSession_chargerId_fkey" FOREIGN KEY ("chargerId") REFERENCES "Charger"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ChargingSession" ADD CONSTRAINT "ChargingSession_hostId_fkey" FOREIGN KEY ("hostId") REFERENCES "HostProfile"("userId") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -41,52 +41,103 @@ model User {
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
 
-  host          HostProfile?
-  driver        DriverProfile?
-  accounts      Account[]
-  sessions      Session[]
+  host     HostProfile?
+  driver   DriverProfile?
+  accounts Account[]
+  sessions Session[]
 }
 
 model HostProfile {
-  userId          String   @id
-  user            User     @relation(fields: [userId], references: [id])
+  userId          String            @id
+  user            User              @relation(fields: [userId], references: [id])
   businessName    String
   bankAccountIban String?
   bankAccountName String?
   chargers        Charger[]
+  sessions        ChargingSession[]
 }
 
 model DriverProfile {
-  userId             String        @id
-  user               User          @relation(fields: [userId], references: [id])
+  userId             String            @id
+  user               User              @relation(fields: [userId], references: [id])
   fullName           String?
   phone              String?
   solanaPubkey       String?
   preferredConnector ConnectorType?
   vehicles           Vehicle[]
+  sessions           ChargingSession[]
 }
 
 model Vehicle {
-  id        String         @id @default(cuid())
+  id        String        @id @default(cuid())
   driverId  String
-  Driver    DriverProfile  @relation(fields: [driverId], references: [userId])
+  Driver    DriverProfile @relation(fields: [driverId], references: [userId])
   model     String?
   connector ConnectorType
-  createdAt DateTime @default(now())
+  createdAt DateTime      @default(now())
+}
+
+enum ChargingStatus {
+  PENDING
+  ACTIVE
+  STOPPED
+  SETTLED
+  CANCELLED
 }
 
 model Charger {
-  id          String      @id @default(cuid())
+  id          String        @id @default(cuid())
   hostId      String
-  host        HostProfile @relation(fields: [hostId], references: [userId])
+  host        HostProfile   @relation(fields: [hostId], references: [userId])
   name        String
   latitude    Float
   longitude   Float
   pricePerKwh Float
   connector   ConnectorType
-  available   Boolean     @default(true)
-  createdAt   DateTime    @default(now())
-  updatedAt   DateTime    @updatedAt
+  available   Boolean       @default(true)
+  powerKw     Float         @default(22)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  sessions ChargingSession[]
+
+  @@index([hostId])
+}
+
+model ChargingSession {
+  id        String @id @default(cuid())
+  driverId  String
+  chargerId String
+  hostId    String
+
+  status ChargingStatus @default(PENDING)
+
+  // Snapshots at START for correct billing
+  pricePerKwhSnapshot Float
+  powerKwSnapshot     Float
+  connectorSnapshot   ConnectorType
+
+  // Times & metering
+  startedAt DateTime  @default(now())
+  stoppedAt DateTime?
+  energyKwh Float? // computed in STOP if you don’t have real meter
+  costTotal Float? // computed in STOP
+
+  // Future blockchain hooks
+  startTxSig String?
+  stopTxSig  String?
+
+  driver  DriverProfile @relation(fields: [driverId], references: [userId])
+  charger Charger       @relation(fields: [chargerId], references: [id])
+  host    HostProfile   @relation(fields: [hostId], references: [userId])
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([driverId, status])
+  @@index([chargerId, status])
+  @@index([hostId, status])
 }
 
 // Auth.js tables

--- a/apps/backend/src/app/api/auth/[...nextauth]/route.ts
+++ b/apps/backend/src/app/api/auth/[...nextauth]/route.ts
@@ -21,15 +21,15 @@ export const authOptions: NextAuthOptions = {
         token.sub = String((user as { id: string }).id);
       }
 
-      // Populate role once (cached via token, then session)
-      if (token.role == null && token.sub) {
-        const u = await prisma.user.findUnique({
-          where: { id: String(token.sub) },
-          select: { role: true },
-        });
-        token.role = u?.role ?? "UNSET";
-      }
-      return token;
+     // refresh role from DB (cheap & consistent for MVP)
+    if (token.sub) {
+      const u = await prisma.user.findUnique({
+        where: { id: String(token.sub) },
+        select: { role: true },
+      });
+      token.role = u?.role ?? "UNSET";
+    }
+    return token;
     },
     async session({ session, token }) {
       if (session.user && token.sub) {

--- a/apps/backend/src/app/api/chargers/[chargerId]/start/route.ts
+++ b/apps/backend/src/app/api/chargers/[chargerId]/start/route.ts
@@ -5,10 +5,13 @@ import { requireDriverContext } from "@/lib/authz";
 
 export async function OPTIONS() { return options(); }
 
-export async function POST(req: NextRequest, { params }: { params: { chargerId: string } }) {
+export async function POST(
+  req: NextRequest,
+  context: { params: { chargerId: string } }
+) {
   try {
     const { userId, driver } = await requireDriverContext(req);
-    const { chargerId } = params;
+    const { chargerId } = context.params;
 
     const charger = await prisma.charger.findUnique({ where: { id: chargerId } });
     if (!charger) return badRequest("Charger not found");

--- a/apps/backend/src/app/api/chargers/[chargerId]/start/route.ts
+++ b/apps/backend/src/app/api/chargers/[chargerId]/start/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/db";
+import { badRequest, forbidden, created, options } from "@/lib/http";
+import { requireDriverContext } from "@/lib/authz";
+
+export async function OPTIONS() { return options(); }
+
+export async function POST(req: NextRequest, { params }: { params: { chargerId: string } }) {
+  try {
+    const { userId, driver } = await requireDriverContext(req);
+    const { chargerId } = params;
+
+    const charger = await prisma.charger.findUnique({ where: { id: chargerId } });
+    if (!charger) return badRequest("Charger not found");
+    if (!charger.available) return forbidden("Charger not available (in use)");
+
+    // enforce single-active-session per driver and charger (MVP: application level)
+    const [driverActive, chargerActive] = await Promise.all([
+      prisma.chargingSession.findFirst({ where: { driverId: userId, status: "ACTIVE" } }),
+      prisma.chargingSession.findFirst({ where: { chargerId, status: "ACTIVE" } }),
+    ]);
+    if (driverActive) return forbidden("Driver already has an active session");
+    if (chargerActive) return forbidden("Charger already has an active session");
+
+    // create session and mark charger unavailable
+    const session = await prisma.$transaction(async (tx) => {
+      const s = await tx.chargingSession.create({
+        data: {
+          driverId: driver.userId,
+          chargerId,
+          hostId: charger.hostId,
+          status: "ACTIVE",
+          pricePerKwhSnapshot: charger.pricePerKwh,
+          powerKwSnapshot: charger.powerKw,
+          connectorSnapshot: charger.connector,
+        },
+      });
+      await tx.charger.update({
+        where: { id: chargerId },
+        data: { available: false },
+      });
+      return s;
+    });
+
+    return created({ session });
+  } catch (e: any) {
+    if (e?.status === 403) return new Response(e.message, { status: 403 });
+    console.error("POST /api/chargers/:id/start failed:", e);
+    return new Response("Internal Server Error", { status: 500 });
+  }
+}

--- a/apps/backend/src/app/api/sessions/[sessionId]/route.ts
+++ b/apps/backend/src/app/api/sessions/[sessionId]/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/db";
+import { ok, badRequest, forbidden, options } from "@/lib/http";
+import { requireDriverContext, requireHostContext } from "@/lib/authz";
+
+export async function OPTIONS() { return options(); }
+
+export async function GET(req: NextRequest, { params }: { params: { sessionId: string } }) {
+  const { sessionId } = params;
+  const session = await prisma.chargingSession.findUnique({ where: { id: sessionId } });
+  if (!session) return badRequest("Session not found");
+
+  // allow driver owner or host owner to view
+  const authHeader = req.headers.get("authorization") || "";
+  const scope = new URL(req.url).searchParams.get("scope");
+
+  try {
+    if (scope === "host") {
+      const { host } = await requireHostContext(req);
+      if (session.hostId !== host.userId) return forbidden("Not your charger");
+      return ok({ session });
+    } else {
+      const { userId } = await requireDriverContext(req);
+      if (session.driverId !== userId) return forbidden("Not your session");
+      return ok({ session });
+    }
+  } catch (e: any) {
+    if (e?.status === 403) return new Response(e.message, { status: 403 });
+    throw e;
+  }
+}

--- a/apps/backend/src/app/api/sessions/[sessionId]/stop/route.ts
+++ b/apps/backend/src/app/api/sessions/[sessionId]/stop/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/db";
+import { badRequest, forbidden, ok, options } from "@/lib/http";
+import { requireDriverContext } from "@/lib/authz";
+
+export async function OPTIONS() { return options(); }
+
+export async function POST(req: NextRequest, { params }: { params: { sessionId: string } }) {
+  try {
+    const { userId } = await requireDriverContext(req);
+    const { sessionId } = params;
+
+    const session = await prisma.chargingSession.findUnique({ where: { id: sessionId } });
+    if (!session) return badRequest("Session not found");
+
+    if (session.driverId !== userId) return forbidden("Not your session");
+    if (session.status !== "ACTIVE") return badRequest("Session is not ACTIVE");
+
+    const now = new Date();
+    const started = session.startedAt;
+    const hours = Math.max(0, (now.getTime() - started.getTime()) / 3600000);
+
+    const energyKwh = session.powerKwSnapshot * hours;
+    const costTotal = energyKwh * session.pricePerKwhSnapshot;
+
+    const updated = await prisma.$transaction(async (tx) => {
+      const s = await tx.chargingSession.update({
+        where: { id: sessionId },
+        data: {
+          status: "STOPPED",
+          stoppedAt: now,
+          energyKwh,
+          costTotal,
+        },
+      });
+      await tx.charger.update({
+        where: { id: session.chargerId },
+        data: { available: true },
+      });
+      return s;
+    });
+
+    return ok({ session: updated });
+  } catch (e: any) {
+    if (e?.status === 403) return new Response(e.message, { status: 403 });
+    console.error("POST /api/sessions/:id/stop failed:", e);
+    return new Response("Internal Server Error", { status: 500 });
+  }
+}

--- a/apps/backend/src/app/api/sessions/route.ts
+++ b/apps/backend/src/app/api/sessions/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/db";
+import { ok, options, forbidden } from "@/lib/http";
+import { requireDriverContext, requireHostContext } from "@/lib/authz";
+
+export async function OPTIONS() { return options(); }
+
+/**
+ * GET /api/sessions?scope=driver|host&page=1&pageSize=20
+ * scope=driver => list the authenticated driver's sessions
+ * scope=host   => list sessions on authenticated host's chargers
+ */
+export async function GET(req: NextRequest) {
+  const url = new URL(req.url);
+  const scope = (url.searchParams.get("scope") || "driver").toLowerCase();
+  const page = Math.max(1, Number(url.searchParams.get("page") || "1"));
+  const pageSize = Math.min(100, Number(url.searchParams.get("pageSize") || "20"));
+
+  if (scope === "host") {
+    const { host } = await requireHostContext(req);
+    const [items, total] = await Promise.all([
+      prisma.chargingSession.findMany({
+        where: { hostId: host.userId },
+        orderBy: { createdAt: "desc" },
+        skip: (page - 1) * pageSize,
+        take: pageSize,
+      }),
+      prisma.chargingSession.count({ where: { hostId: host.userId } }),
+    ]);
+    return ok({ items, page, pageSize, total });
+  } else {
+    const { userId } = await requireDriverContext(req);
+    const [items, total] = await Promise.all([
+      prisma.chargingSession.findMany({
+        where: { driverId: userId },
+        orderBy: { createdAt: "desc" },
+        skip: (page - 1) * pageSize,
+        take: pageSize,
+      }),
+      prisma.chargingSession.count({ where: { driverId: userId } }),
+    ]);
+    return ok({ items, page, pageSize, total });
+  }
+}

--- a/apps/backend/src/lib/authz.ts
+++ b/apps/backend/src/lib/authz.ts
@@ -1,0 +1,20 @@
+import { prisma } from "@/lib/db";
+import { requireUserId } from "@/lib/api-auth";
+
+export async function requireDriverContext(req: Request) {
+  const userId = await requireUserId(req as any);
+  const driver = await prisma.driverProfile.findUnique({ where: { userId } });
+  if (!driver) {
+    throw Object.assign(new Error("Driver profile required"), { status: 403, name: "ForbiddenError" });
+  }
+  return { userId, driver };
+}
+
+export async function requireHostContext(req: Request) {
+  const userId = await requireUserId(req as any);
+  const host = await prisma.hostProfile.findUnique({ where: { userId } });
+  if (!host) {
+    throw Object.assign(new Error("Host profile required"), { status: 403, name: "ForbiddenError" });
+  }
+  return { userId, host };
+}

--- a/apps/backend/src/lib/solana.ts
+++ b/apps/backend/src/lib/solana.ts
@@ -29,3 +29,17 @@ export function clusterQueryParam(): "devnet" | "testnet" | "mainnet" {
   if (url.includes("testnet")) return "testnet";
   return "mainnet";
 }
+
+export type SolanaTxKind = "START" | "STOP";
+
+export type SolanaTxResult = {
+  signature: string; // tx sig
+};
+
+export async function sendSessionTx(_kind: SolanaTxKind, _args: { sessionId: string }) : Promise<SolanaTxResult> {
+  // Placeholder for later:
+  // 1) load payer
+  // 2) build instruction(s)
+  // 3) send & confirm
+  return { signature: "SIMULATED_SIG" };
+}


### PR DESCRIPTION
# Charging Sessions (Start/Stop) — Backend

## Overview
Implements the core **Start/Stop charging session** flow with role-aware authentication, pricing/power snapshots at session start, automatic energy and cost computation at stop, and host/driver session queries.  
Includes groundwork for future Solana transaction integration.

---

## feat(db): add ChargingSession model
- Added new `ChargingSession` model and `ChargingStatus` enum.
- Snapshots: `pricePerKwhSnapshot`, `powerKwSnapshot`, `connectorSnapshot`.
- Added `Charger.powerKw` (default 22 kW) and indexing for performance.
- Added back-relations on `DriverProfile`, `HostProfile`, and `Charger`.

## chore(api): add auth helpers
- Introduced `requireDriverContext` and `requireHostContext`.
- Centralized profile validation and role enforcement.
- Simplifies route handlers and ensures consistent 403 responses.

## feat(api): driver START session
- Added `POST /api/chargers/[chargerId]/start` route.
- Validates driver role and charger availability.
- Prevents multiple active sessions for the same driver/charger.
- Creates session with snapshots and marks charger unavailable.

## feat(api): driver STOP session
- Added `POST /api/sessions/[sessionId]/stop` route.
- Allows only the original driver to stop their session.
- Computes session duration, energy (kWh), and cost (total).
- Marks session as `STOPPED` and frees charger for reuse.

## feat(api): sessions listing & details
- Added `GET /api/sessions` with `scope=driver|host` query param.
- Added `GET /api/sessions/[sessionId]` for detailed view.
- Both endpoints enforce role-based access and pagination.

## chore(solana): placeholder module
- Added `sendSessionTx(kind, { sessionId })` stub in `lib/solana.ts`.
- Prepares integration point for future Solana tx emission (`startTxSig` / `stopTxSig`).

## docs: add cURL examples
- Added `SESSION_API_EXAMPLES.md` with ready-to-run curl commands.
- Demonstrates session start, stop, listing, and detail requests.
