### PR TITLE
Darko/solana register user

### DIFF
--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "backend",
       "version": "0.1.0",
       "dependencies": {
+        "@coral-xyz/anchor": "^0.32.1",
         "@next-auth/prisma-adapter": "^1.0.7",
         "@prisma/client": "^6.16.3",
         "@solana/web3.js": "^1.98.4",
@@ -38,6 +39,85 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@coral-xyz/anchor": {
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/anchor/-/anchor-0.32.1.tgz",
+      "integrity": "sha512-zAyxFtfeje2FbMA1wzgcdVs7Hng/MijPKpRijoySPCicnvcTQs/+dnPZ/cR+LcXM9v9UYSyW81uRNYZtN5G4yg==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@coral-xyz/anchor-errors": "^0.31.1",
+        "@coral-xyz/borsh": "^0.31.1",
+        "@noble/hashes": "^1.3.1",
+        "@solana/web3.js": "^1.69.0",
+        "bn.js": "^5.1.2",
+        "bs58": "^4.0.1",
+        "buffer-layout": "^1.2.2",
+        "camelcase": "^6.3.0",
+        "cross-fetch": "^3.1.5",
+        "eventemitter3": "^4.0.7",
+        "pako": "^2.0.3",
+        "superstruct": "^0.15.4",
+        "toml": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=17"
+      }
+    },
+    "node_modules/@coral-xyz/anchor-errors": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/anchor-errors/-/anchor-errors-0.31.1.tgz",
+      "integrity": "sha512-NhNEku4F3zzUSBtrYz84FzYWm48+9OvmT1Hhnwr6GnPQry2dsEqH/ti/7ASjjpoFTWRnPXrjAIT1qM6Isop+LQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@coral-xyz/anchor/node_modules/base-x": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@coral-xyz/anchor/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/@coral-xyz/anchor/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/@coral-xyz/anchor/node_modules/superstruct": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.15.5.tgz",
+      "integrity": "sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ==",
+      "license": "MIT"
+    },
+    "node_modules/@coral-xyz/borsh": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.31.1.tgz",
+      "integrity": "sha512-9N8AU9F0ubriKfNE3g1WF0/4dtlGXoBN/hd1PvbNBamBNwRgHxH4P+o3Zt7rSEloW1HUs6LfZEchlx9fW7POYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bn.js": "^5.1.2",
+        "buffer-layout": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.69.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -2243,6 +2323,15 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/buffer-layout": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/buffer-layout/-/buffer-layout-1.2.2.tgz",
+      "integrity": "sha512-kWSuLN694+KTk8SrYvCqwP2WcgQjoRCiF5b4QDvkkz8EmgD+aWAIceGFKMIAdmF/pH+vpgNV3d3kAKorcdAmWA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.5"
+      }
+    },
     "node_modules/bufferutil": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.9.tgz",
@@ -2344,6 +2433,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/caniuse-lite": {
@@ -2475,6 +2576,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -5087,6 +5197,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -6156,6 +6272,12 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+      "license": "MIT"
     },
     "node_modules/tr46": {
       "version": "0.0.3",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@coral-xyz/anchor": "^0.32.1",
     "@next-auth/prisma-adapter": "^1.0.7",
     "@prisma/client": "^6.16.3",
     "@solana/web3.js": "^1.98.4",

--- a/apps/backend/prisma/migrations/20251014101230_user_sol_registry_fields/migration.sql
+++ b/apps/backend/prisma/migrations/20251014101230_user_sol_registry_fields/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "solanaRegisterTx" TEXT,
+ADD COLUMN     "solanaUserPda" TEXT;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -41,6 +41,9 @@ model User {
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
 
+  solanaUserPda      String?
+  solanaRegisterTx   String?
+
   host     HostProfile?
   driver   DriverProfile?
   accounts Account[]

--- a/apps/backend/src/lib/solana.ts
+++ b/apps/backend/src/lib/solana.ts
@@ -1,4 +1,14 @@
-import { Connection, Keypair, clusterApiUrl, PublicKey, TransactionInstruction, Transaction, SystemProgram } from "@solana/web3.js";
+import {
+  Connection,
+  Keypair,
+  clusterApiUrl,
+  PublicKey,
+  TransactionInstruction,
+  Transaction,
+  SystemProgram,
+} from "@solana/web3.js";
+import * as anchor from "@coral-xyz/anchor";
+import type { Idl } from "@coral-xyz/anchor";
 import bs58 from "bs58";
 import fs from "node:fs";
 import crypto from "node:crypto";
@@ -15,7 +25,7 @@ function loadKeypair(): Keypair {
 
   const file = process.env.SOLANA_PAYER_SECRET_FILE;
   if (file && fs.existsSync(file)) {
-    const raw = JSON.parse(fs.readFileSync(file, "utf8"));
+    const raw = JSON.parse(fs.readFileSync(file, "utf8")) as number[];
     const secretKey = Uint8Array.from(raw);
     return Keypair.fromSecretKey(secretKey);
   }
@@ -38,85 +48,113 @@ export type SolanaTxResult = {
   signature: string; // tx sig
 };
 
-export async function sendSessionTx(_kind: SolanaTxKind, _args: { sessionId: string }) : Promise<SolanaTxResult> {
-  // Placeholder for later:
-  // 1) load payer
-  // 2) build instruction(s)
-  // 3) send & confirm
+export async function sendSessionTx(
+  _kind: SolanaTxKind,
+  _args: { sessionId: string }
+): Promise<SolanaTxResult> {
+  // mark as intentionally unused (avoids @typescript-eslint/no-unused-vars)
+  void _kind;
+  void _args;
+
+  // Placeholder for later: 1) build ix 2) send & confirm
   return { signature: "SIMULATED_SIG" };
 }
 
 // Map your app roles to a compact u8 value used by the program
 function roleToU8(role: "HOST" | "DRIVER" | "UNSET" | "ADMIN"): number {
   switch (role) {
-    case "HOST": return 1;
-    case "DRIVER": return 2;
-    case "ADMIN": return 3;
+    case "HOST":
+      return 1;
+    case "DRIVER":
+      return 2;
+    case "ADMIN":
+      return 3;
     case "UNSET":
-    default: return 0;
+    default:
+      return 0;
   }
 }
 
 function hashUserIdTo32(userId: string): Buffer {
   // Deterministic 32-byte hash
-  return crypto.createHash("sha256").update(userId, "utf8").digest().subarray(0, 32);
+  return crypto
+    .createHash("sha256")
+    .update(userId, "utf8")
+    .digest()
+    .subarray(0, 32);
 }
+
+/** Extend the Anchor Idl with the discriminator present in built JSONs */
+type IdlWithDisc = Idl & {
+  metadata?: { address?: string };
+  address?: string;
+  instructions: Array<{ name: string; discriminator: number[] }>;
+};
 
 /**
  * Register a user on-chain (devnet) via Anchor-compatible flow.
  * Returns { signature, userPda }.
  * Idempotent at the PDA level (your program should no-op if already initialized).
  */
-export async function registerUserOnChain(userId: string, role: "HOST" | "DRIVER" | "UNSET" | "ADMIN") {
-  // Anchor dynamic import (keeps workspace resolution lazy)
-  const anchor: any = await import("@coral-xyz/anchor");
+export async function registerUserOnChain(
+  userId: string,
+  role: "HOST" | "DRIVER" | "UNSET" | "ADMIN"
+) {
+  // If the project is launched via `anchor test`/env, this binds to env provider.
+  anchor.setProvider(anchor.AnchorProvider.env());
+  const provider = anchor.getProvider() as anchor.AnchorProvider;
+  const wallet = provider.wallet as anchor.Wallet;
 
-  // Find Anchor.toml / IDL, default to repo root/target/idl
+  // Resolve Anchor workspace root and load IDL JSON (no require())
   const probableProgramRoot = path.resolve(__dirname, "..", ".."); // adjust if needed
   const anchorTomlPath = path.join(probableProgramRoot, "Anchor.toml");
   if (fs.existsSync(anchorTomlPath)) process.chdir(probableProgramRoot);
 
-  const idl = require(path.join(process.cwd(), "target", "idl", "topcharger_program.json"));
-  const programId = new PublicKey(
-    process.env.TOPCHARGER_PROGRAM_ID ?? idl.metadata?.address ?? (idl.address as string)
+  const idlPath = path.join(
+    process.cwd(),
+    "target",
+    "idl",
+    "topcharger_program.json"
   );
+  const idl = JSON.parse(fs.readFileSync(idlPath, "utf8")) as IdlWithDisc;
 
-  anchor.setProvider(anchor.AnchorProvider.env());
-  const provider: any = anchor.getProvider();
+  const programId = new PublicKey(
+    process.env.TOPCHARGER_PROGRAM_ID ??
+      idl.metadata?.address ??
+      (idl.address as string)
+  );
 
   const roleU8 = roleToU8(role);
   const userHash = hashUserIdTo32(userId);
 
-  // Don’t await the sync call—it returns [PublicKey, bump] immediately.
   const [userPda] = PublicKey.findProgramAddressSync(
-  [Buffer.from("user"), userHash], // Array<Buffer | Uint8Array>
-  programId
-);
+    [Buffer.from("user"), userHash],
+    programId
+  );
 
-  // Build instruction data from IDL discriminator + args (u8 + [u8;32])
-  const ixDesc = idl.instructions.find((ix: any) => ix.name === "register_user");
+  const ixDesc = idl.instructions.find((ix) => ix.name === "register_user");
   if (!ixDesc) throw new Error("register_user instruction not found in IDL");
+
   const discriminator = Buffer.from(ixDesc.discriminator);
   const argsBuf = Buffer.concat([Buffer.from([roleU8 & 0xff]), userHash]);
   const data = Buffer.concat([discriminator, argsBuf]);
 
   const keys = [
     { pubkey: userPda, isSigner: false, isWritable: true },
-    { pubkey: provider.wallet.publicKey, isSigner: false, isWritable: false }, // authority
-    { pubkey: provider.wallet.publicKey, isSigner: true, isWritable: true },   // payer
+    { pubkey: wallet.publicKey, isSigner: false, isWritable: false }, // authority
+    { pubkey: wallet.publicKey, isSigner: true, isWritable: true }, // payer
     { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
   ];
 
   const ix = new TransactionInstruction({ programId, keys, data });
 
-  // Build/send
   const tx = new Transaction().add(ix);
-  tx.feePayer = provider.wallet.publicKey;
+  tx.feePayer = wallet.publicKey;
 
   const latest = await provider.connection.getLatestBlockhash();
   tx.recentBlockhash = latest.blockhash;
 
-  const signed = await provider.wallet.signTransaction(tx);
+  const signed = await wallet.signTransaction(tx);
   const sig = await provider.connection.sendRawTransaction(signed.serialize());
   await provider.connection.confirmTransaction({
     signature: sig,

--- a/apps/backend/src/lib/solana.ts
+++ b/apps/backend/src/lib/solana.ts
@@ -1,6 +1,8 @@
-import { Connection, Keypair, clusterApiUrl } from "@solana/web3.js";
+import { Connection, Keypair, clusterApiUrl, PublicKey, TransactionInstruction, Transaction, SystemProgram } from "@solana/web3.js";
 import bs58 from "bs58";
 import fs from "node:fs";
+import crypto from "node:crypto";
+import path from "node:path";
 
 export const connection = new Connection(
   process.env.SOLANA_RPC_URL || clusterApiUrl("devnet"),
@@ -42,4 +44,85 @@ export async function sendSessionTx(_kind: SolanaTxKind, _args: { sessionId: str
   // 2) build instruction(s)
   // 3) send & confirm
   return { signature: "SIMULATED_SIG" };
+}
+
+// Map your app roles to a compact u8 value used by the program
+function roleToU8(role: "HOST" | "DRIVER" | "UNSET" | "ADMIN"): number {
+  switch (role) {
+    case "HOST": return 1;
+    case "DRIVER": return 2;
+    case "ADMIN": return 3;
+    case "UNSET":
+    default: return 0;
+  }
+}
+
+function hashUserIdTo32(userId: string): Buffer {
+  // Deterministic 32-byte hash
+  return crypto.createHash("sha256").update(userId, "utf8").digest().subarray(0, 32);
+}
+
+/**
+ * Register a user on-chain (devnet) via Anchor-compatible flow.
+ * Returns { signature, userPda }.
+ * Idempotent at the PDA level (your program should no-op if already initialized).
+ */
+export async function registerUserOnChain(userId: string, role: "HOST" | "DRIVER" | "UNSET" | "ADMIN") {
+  // Anchor dynamic import (keeps workspace resolution lazy)
+  const anchor: any = await import("@coral-xyz/anchor");
+
+  // Find Anchor.toml / IDL, default to repo root/target/idl
+  const probableProgramRoot = path.resolve(__dirname, "..", ".."); // adjust if needed
+  const anchorTomlPath = path.join(probableProgramRoot, "Anchor.toml");
+  if (fs.existsSync(anchorTomlPath)) process.chdir(probableProgramRoot);
+
+  const idl = require(path.join(process.cwd(), "target", "idl", "topcharger_program.json"));
+  const programId = new PublicKey(
+    process.env.TOPCHARGER_PROGRAM_ID ?? idl.metadata?.address ?? (idl.address as string)
+  );
+
+  anchor.setProvider(anchor.AnchorProvider.env());
+  const provider: any = anchor.getProvider();
+
+  const roleU8 = roleToU8(role);
+  const userHash = hashUserIdTo32(userId);
+
+  // Don’t await the sync call—it returns [PublicKey, bump] immediately.
+  const [userPda] = PublicKey.findProgramAddressSync(
+  [Buffer.from("user"), userHash], // Array<Buffer | Uint8Array>
+  programId
+);
+
+  // Build instruction data from IDL discriminator + args (u8 + [u8;32])
+  const ixDesc = idl.instructions.find((ix: any) => ix.name === "register_user");
+  if (!ixDesc) throw new Error("register_user instruction not found in IDL");
+  const discriminator = Buffer.from(ixDesc.discriminator);
+  const argsBuf = Buffer.concat([Buffer.from([roleU8 & 0xff]), userHash]);
+  const data = Buffer.concat([discriminator, argsBuf]);
+
+  const keys = [
+    { pubkey: userPda, isSigner: false, isWritable: true },
+    { pubkey: provider.wallet.publicKey, isSigner: false, isWritable: false }, // authority
+    { pubkey: provider.wallet.publicKey, isSigner: true, isWritable: true },   // payer
+    { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+  ];
+
+  const ix = new TransactionInstruction({ programId, keys, data });
+
+  // Build/send
+  const tx = new Transaction().add(ix);
+  tx.feePayer = provider.wallet.publicKey;
+
+  const latest = await provider.connection.getLatestBlockhash();
+  tx.recentBlockhash = latest.blockhash;
+
+  const signed = await provider.wallet.signTransaction(tx);
+  const sig = await provider.connection.sendRawTransaction(signed.serialize());
+  await provider.connection.confirmTransaction({
+    signature: sig,
+    blockhash: latest.blockhash,
+    lastValidBlockHeight: latest.lastValidBlockHeight,
+  });
+
+  return { signature: sig as string, userPda: userPda.toBase58() };
 }


### PR DESCRIPTION
# PR: Register User on Solana Devnet After Role Assignment

## Overview
This PR introduces the first **Solana devnet integration** for TopCharger.  
When a user is assigned a role (`HOST` or `DRIVER`) through the backend, the system now automatically registers them on-chain by calling the `register_user` instruction in the **TopCharger Solana program**.

Each user is assigned a **Program-Derived Address (PDA)** — a unique on-chain account controlled by the program — which serves as their persistent identity on Solana.

---

## Changes

### ✅ Database
- Added new optional fields to the `User` model:
  - `solanaUserPda` — user’s PDA address on Solana.
  - `solanaRegisterTx` — Solana transaction signature.
  - `solanaRegisteredAt` — timestamp of on-chain registration.

### ✅ Backend Logic
- Added helper `registerUserOnChain()` in `lib/solana.ts`:
  - Connects to **Solana devnet** using `@coral-xyz/anchor`.
  - Loads program ID and IDL (`topcharger_program.json`).
  - Derives deterministic user PDA using:
    ```
    seeds = ["user", sha256(userId)]
    ```
  - Sends `register_user` transaction with role (u8) and user hash ([u8;32]).
- Updated `POST /api/hosts/profile` and `POST /api/drivers/profile`:
  - On first-time role assignment, triggers `registerUserOnChain()`.
  - Persists PDA, transaction signature, and timestamp in DB.

### ✅ Configuration
- Requires the following environment variables in `.env.local`:
  ```env
  SOLANA_RPC_URL=https://api.devnet.solana.com
  SOLANA_PAYER_SECRET_FILE=/absolute/path/to/payer.json
  ANCHOR_PROVIDER_URL=https://api.devnet.solana.com
  ANCHOR_WALLET=/absolute/path/to/payer.json
  TOPCHARGER_PROGRAM_ID=<YourProgramPubkey>
