### PR TITLE
Darko/solana fixes

### DIFF
--- a/apps/backend/src/app/api/solana/user/route.ts
+++ b/apps/backend/src/app/api/solana/user/route.ts
@@ -1,0 +1,23 @@
+export const runtime = "nodejs";
+
+import { NextRequest } from "next/server";
+import { ok, badRequest, notFound, options } from "@/lib/http";
+import { fetchUserAccountByUserId } from "@/lib/solana";
+
+export function OPTIONS() { return options(); }
+
+/** GET /api/solana/user?userId=<backendUserId> */
+export async function GET(req: NextRequest) {
+  const url = new URL(req.url);
+  const userId = url.searchParams.get("userId");
+  if (!userId) return badRequest("Missing userId");
+
+  try {
+    const acc = await fetchUserAccountByUserId(userId);
+    if (!acc) return notFound("User PDA not found");
+    return ok(acc);
+  } catch (e: any) {
+    console.error("GET /api/solana/user failed:", e);
+    return badRequest(e?.message || "Failed to fetch user PDA");
+  }
+}

--- a/apps/backend/src/app/api/solana/user/route.ts
+++ b/apps/backend/src/app/api/solana/user/route.ts
@@ -1,10 +1,13 @@
+// apps/backend/src/app/api/solana/user/route.ts
 export const runtime = "nodejs";
 
 import { NextRequest } from "next/server";
 import { ok, badRequest, notFound, options } from "@/lib/http";
 import { fetchUserAccountByUserId } from "@/lib/solana";
 
-export function OPTIONS() { return options(); }
+export function OPTIONS() {
+  return options();
+}
 
 /** GET /api/solana/user?userId=<backendUserId> */
 export async function GET(req: NextRequest) {
@@ -16,8 +19,14 @@ export async function GET(req: NextRequest) {
     const acc = await fetchUserAccountByUserId(userId);
     if (!acc) return notFound("User PDA not found");
     return ok(acc);
-  } catch (e: any) {
+  } catch (e: unknown) {
+    const message =
+      e instanceof Error
+        ? e.message
+        : typeof e === "string"
+        ? e
+        : "Failed to fetch user PDA";
     console.error("GET /api/solana/user failed:", e);
-    return badRequest(e?.message || "Failed to fetch user PDA");
+    return badRequest(String(message));
   }
 }


### PR DESCRIPTION
# PR: Solana User Query Endpoint + Role Mapping Alignment

## Overview
Adds a **read-only Solana endpoint** to fetch and decode a user’s on-chain PDA account by backend `userId`.  
Aligns **role → u8** mapping with on-chain semantics and introduces helper utilities for PDA derivation and manual account decoding (no IDL required).

---

## New Endpoint
### `GET /api/solana/user?userId=<BACKEND_USER_ID>`
- Returns decoded **User PDA** data:
  - `pda`, `owner`, `lamports`
  - `userIdHashHex`
  - `roleU8`, `role` (`DRIVER`/`HOST`)
  - `wallet` (authority)
- CORS/JSON via shared `http.ts` helpers.
- Node runtime: `export const runtime = "nodejs"`.

---

## Role Mapping (aligned to on-chain)
```ts
function roleToU8(role: "HOST" | "DRIVER" | "UNSET" | "ADMIN"): number {
  switch (role) {
    case "HOST":   return 1; // on-chain: 1 = host
    case "DRIVER": return 0; // on-chain: 0 = driver
    case "ADMIN":  return 2;
    case "UNSET":
    default:       return 3;
  }
}
