### PR TITLE
Darko/solana create charger

### DIFF
--- a/apps/backend/CHAIN_CHARGER.md
+++ b/apps/backend/CHAIN_CHARGER.md
@@ -1,0 +1,23 @@
+# On-chain Charger Creation (Devnet)
+
+## Env
+
+`TOPCHARGER_PROGRAM_ID=<YourProgramPubkey>
+SOLANA_RPC_URL=https://api.devnet.solana.com
+SOLANA_PAYER_SECRET_FILE=/absolute/path/to/apps/backend/payer.json`
+
+## Flow
+1. Host creates charger via `POST /api/hosts/chargers`.
+2. Backend:
+   - Creates charger in DB.
+   - Computes `chainId = hashToU64(charger.id)`.
+   - Calls `create_charger` on Solana devnet with:
+     - seeds: `["charger", sha256(userId)[0..32], charger_id(u64 LE)]`
+     - args: `user_id_hash (32)`, `charger_id (u64)`, `power_kw (u16)`, `supply_type (u8)`, `price (u64 microusd/kWh)`
+   - Persists `solanaChargerPda`, `solanaCreateTx`.
+
+## Notes
+- Unit for `price` is **microusd/kWh** (u64).
+- `chainId` is a deterministic u64 derived from Prisma `charger.id` and saved back to DB.
+- MVP uses `payer` as both `wallet` and `authority`.
+- Failures to write on-chain are **non-blocking** for the API; UI can show a "sync failed" state.

--- a/apps/backend/prisma/migrations/20251015074657_charger_chain_fields/migration.sql
+++ b/apps/backend/prisma/migrations/20251015074657_charger_chain_fields/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "Charger" ADD COLUMN     "chainId" BIGINT,
+ADD COLUMN     "solanaChargerPda" TEXT,
+ADD COLUMN     "solanaCreateTx" TEXT;

--- a/apps/backend/prisma/migrations/20251015121546_chargers_chainid_deleted/migration.sql
+++ b/apps/backend/prisma/migrations/20251015121546_chargers_chainid_deleted/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `chainId` on the `Charger` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Charger" DROP COLUMN "chainId";

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -103,6 +103,12 @@ model Charger {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  //u64 identifier used for PDA seed (derived & persisted)
+  chainId          BigInt?     @db.BigInt
+  //on-chain identity
+  solanaChargerPda String?
+  solanaCreateTx   String?
+
   sessions ChargingSession[]
 
   @@index([hostId])

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -103,8 +103,6 @@ model Charger {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  //u64 identifier used for PDA seed (derived & persisted)
-  chainId          BigInt?     @db.BigInt
   //on-chain identity
   solanaChargerPda String?
   solanaCreateTx   String?

--- a/apps/backend/src/app/api/chargers/route.ts
+++ b/apps/backend/src/app/api/chargers/route.ts
@@ -2,33 +2,33 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/db";
 import { ok, options } from "@/lib/http";
-import type { Prisma, ConnectorType } from "@/generated/prisma"; // <- matches your generator output
+import type { Prisma } from "@/generated/prisma"; // type-only OK
+import { ConnectorType } from "@/generated/prisma"; // <-- value import
 
-// Type guard to keep TS happy and avoid `any`
 function isConnectorType(v: string): v is ConnectorType {
   return (Object.values(ConnectorType) as string[]).includes(v);
 }
 
-// CORS preflight
 export function OPTIONS() {
   return options();
 }
 
-// Public list of ALL chargers (paginated, newest first)
 export async function GET(req: NextRequest) {
   const url = new URL(req.url);
 
   const page = Math.max(1, Number(url.searchParams.get("page") ?? "1"));
-  const pageSize = Math.min(Math.max(1, Number(url.searchParams.get("pageSize") ?? "20")), 100);
+  const pageSize = Math.min(
+    Math.max(1, Number(url.searchParams.get("pageSize") ?? "20")),
+    100
+  );
 
-  // Optional simple filters
-  const connectorParam = url.searchParams.get("connector"); // e.g. TYPE2
-  const availableParam = url.searchParams.get("available"); // "true" | "false" | null
+  const connectorParam = url.searchParams.get("connector");
+  const availableParam = url.searchParams.get("available");
 
   const where: Prisma.ChargerWhereInput = {};
 
   if (connectorParam && isConnectorType(connectorParam)) {
-    where.connector = connectorParam; // typed as ConnectorType
+    where.connector = connectorParam;
   }
 
   if (availableParam === "true") where.available = true;

--- a/apps/backend/src/app/api/sessions/[sessionId]/route.ts
+++ b/apps/backend/src/app/api/sessions/[sessionId]/route.ts
@@ -12,29 +12,25 @@ export async function GET(
   { params }: { params: { sessionId: string } }
 ) {
   const { sessionId } = params;
-  const session = await prisma.chargingSession.findUnique({
-    where: { id: sessionId },
-  });
+  const session = await prisma.chargingSession.findUnique({ where: { id: sessionId } });
   if (!session) return badRequest("Session not found");
 
   const scope = new URL(req.url).searchParams.get("scope");
 
   try {
     if (scope === "host") {
-      const { host } = await requireHostContext(req as unknown as Request);
+      const { host } = await requireHostContext(req);
       if (session.hostId !== host.userId) return forbidden("Not your charger");
       return ok({ session });
     } else {
-      const { userId } = await requireDriverContext(req as unknown as Request);
+      const { userId } = await requireDriverContext(req);
       if (session.driverId !== userId) return forbidden("Not your session");
       return ok({ session });
     }
   } catch (e: unknown) {
     const status = (e as { status?: number } | null)?.status;
-    const message =
-      e instanceof Error ? e.message : typeof e === "string" ? e : "Forbidden";
+    const message = e instanceof Error ? e.message : typeof e === "string" ? e : "Forbidden";
     if (status === 403) return new Response(message, { status: 403 });
-    // rethrow or normalize
     console.error("GET /api/sessions/:id failed:", e);
     return new Response("Internal Server Error", { status: 500 });
   }

--- a/apps/backend/src/app/api/sessions/[sessionId]/route.ts
+++ b/apps/backend/src/app/api/sessions/[sessionId]/route.ts
@@ -3,29 +3,39 @@ import { prisma } from "@/lib/db";
 import { ok, badRequest, forbidden, options } from "@/lib/http";
 import { requireDriverContext, requireHostContext } from "@/lib/authz";
 
-export async function OPTIONS() { return options(); }
+export async function OPTIONS() {
+  return options();
+}
 
-export async function GET(req: NextRequest, { params }: { params: { sessionId: string } }) {
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { sessionId: string } }
+) {
   const { sessionId } = params;
-  const session = await prisma.chargingSession.findUnique({ where: { id: sessionId } });
+  const session = await prisma.chargingSession.findUnique({
+    where: { id: sessionId },
+  });
   if (!session) return badRequest("Session not found");
 
-  // allow driver owner or host owner to view
-  const authHeader = req.headers.get("authorization") || "";
   const scope = new URL(req.url).searchParams.get("scope");
 
   try {
     if (scope === "host") {
-      const { host } = await requireHostContext(req);
+      const { host } = await requireHostContext(req as unknown as Request);
       if (session.hostId !== host.userId) return forbidden("Not your charger");
       return ok({ session });
     } else {
-      const { userId } = await requireDriverContext(req);
+      const { userId } = await requireDriverContext(req as unknown as Request);
       if (session.driverId !== userId) return forbidden("Not your session");
       return ok({ session });
     }
-  } catch (e: any) {
-    if (e?.status === 403) return new Response(e.message, { status: 403 });
-    throw e;
+  } catch (e: unknown) {
+    const status = (e as { status?: number } | null)?.status;
+    const message =
+      e instanceof Error ? e.message : typeof e === "string" ? e : "Forbidden";
+    if (status === 403) return new Response(message, { status: 403 });
+    // rethrow or normalize
+    console.error("GET /api/sessions/:id failed:", e);
+    return new Response("Internal Server Error", { status: 500 });
   }
 }

--- a/apps/backend/src/app/api/sessions/[sessionId]/stop/route.ts
+++ b/apps/backend/src/app/api/sessions/[sessionId]/stop/route.ts
@@ -3,14 +3,21 @@ import { prisma } from "@/lib/db";
 import { badRequest, forbidden, ok, options } from "@/lib/http";
 import { requireDriverContext } from "@/lib/authz";
 
-export async function OPTIONS() { return options(); }
+export async function OPTIONS() {
+  return options();
+}
 
-export async function POST(req: NextRequest, { params }: { params: { sessionId: string } }) {
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { sessionId: string } }
+) {
   try {
-    const { userId } = await requireDriverContext(req);
+    const { userId } = await requireDriverContext(req as unknown as Request); // keep cast if requireUserId expects Request
     const { sessionId } = params;
 
-    const session = await prisma.chargingSession.findUnique({ where: { id: sessionId } });
+    const session = await prisma.chargingSession.findUnique({
+      where: { id: sessionId },
+    });
     if (!session) return badRequest("Session not found");
 
     if (session.driverId !== userId) return forbidden("Not your session");
@@ -41,8 +48,15 @@ export async function POST(req: NextRequest, { params }: { params: { sessionId: 
     });
 
     return ok({ session: updated });
-  } catch (e: any) {
-    if (e?.status === 403) return new Response(e.message, { status: 403 });
+  } catch (e: unknown) {
+    const status = (e as { status?: number } | null)?.status;
+    const message =
+      e instanceof Error
+        ? e.message
+        : typeof e === "string"
+        ? e
+        : "Internal Server Error";
+    if (status === 403) return new Response(message, { status: 403 });
     console.error("POST /api/sessions/:id/stop failed:", e);
     return new Response("Internal Server Error", { status: 500 });
   }

--- a/apps/backend/src/app/api/sessions/route.ts
+++ b/apps/backend/src/app/api/sessions/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/db";
-import { ok, options, forbidden } from "@/lib/http";
+import { ok, options } from "@/lib/http";
 import { requireDriverContext, requireHostContext } from "@/lib/authz";
 
 export async function OPTIONS() { return options(); }

--- a/apps/backend/src/lib/authz.ts
+++ b/apps/backend/src/lib/authz.ts
@@ -11,17 +11,13 @@ function forbiddenError(msg: string): ForbiddenError {
 export async function requireDriverContext(req: NextRequest) {
   const userId = await requireUserId(req);
   const driver = await prisma.driverProfile.findUnique({ where: { userId } });
-  if (!driver) {
-    throw forbiddenError("Driver profile required");
-  }
+  if (!driver) throw forbiddenError("Driver profile required");
   return { userId, driver };
 }
 
 export async function requireHostContext(req: NextRequest) {
   const userId = await requireUserId(req);
   const host = await prisma.hostProfile.findUnique({ where: { userId } });
-  if (!host) {
-    throw forbiddenError("Host profile required");
-  }
+  if (!host) throw forbiddenError("Host profile required");
   return { userId, host };
 }

--- a/apps/backend/src/lib/authz.ts
+++ b/apps/backend/src/lib/authz.ts
@@ -1,20 +1,27 @@
 import { prisma } from "@/lib/db";
 import { requireUserId } from "@/lib/api-auth";
+import type { NextRequest } from "next/server";
 
-export async function requireDriverContext(req: Request) {
-  const userId = await requireUserId(req as any);
+type ForbiddenError = Error & { status?: number; name?: string };
+
+function forbiddenError(msg: string): ForbiddenError {
+  return Object.assign(new Error(msg), { status: 403, name: "ForbiddenError" });
+}
+
+export async function requireDriverContext(req: NextRequest) {
+  const userId = await requireUserId(req);
   const driver = await prisma.driverProfile.findUnique({ where: { userId } });
   if (!driver) {
-    throw Object.assign(new Error("Driver profile required"), { status: 403, name: "ForbiddenError" });
+    throw forbiddenError("Driver profile required");
   }
   return { userId, driver };
 }
 
-export async function requireHostContext(req: Request) {
-  const userId = await requireUserId(req as any);
+export async function requireHostContext(req: NextRequest) {
+  const userId = await requireUserId(req);
   const host = await prisma.hostProfile.findUnique({ where: { userId } });
   if (!host) {
-    throw Object.assign(new Error("Host profile required"), { status: 403, name: "ForbiddenError" });
+    throw forbiddenError("Host profile required");
   }
   return { userId, host };
 }

--- a/apps/backend/src/lib/solana.ts
+++ b/apps/backend/src/lib/solana.ts
@@ -173,11 +173,17 @@ function roleFromU8(n: number): "DRIVER" | "HOST" | "UNKNOWN" {
 }
 
 function sha256_32(userId: string): Buffer {
-  return crypto.createHash("sha256").update(userId, "utf8").digest().subarray(0, 32);
+  return crypto
+    .createHash("sha256")
+    .update(userId, "utf8")
+    .digest()
+    .subarray(0, 32);
 }
 
 /** Derive the User PDA from backend userId (no IDL needed). */
-export async function deriveUserPdaFromUserId(userId: string): Promise<PublicKey> {
+export async function deriveUserPdaFromUserId(
+  userId: string
+): Promise<PublicKey> {
   const programIdStr = process.env.TOPCHARGER_PROGRAM_ID;
   if (!programIdStr) throw new Error("TOPCHARGER_PROGRAM_ID not set");
   const programId = new PublicKey(programIdStr);
@@ -193,12 +199,13 @@ export async function deriveUserPdaFromUserId(userId: string): Promise<PublicKey
 /** Manual decode of the on-chain User account without IDL (Anchor discriminator + struct). */
 function decodeUserAccount(data: Buffer) {
   // Expect 8 (disc) + 32 (hash) + 1 (role) + 32 (wallet) = 73 bytes
-  if (data.length < 73) throw new Error(`User account too small: ${data.length} bytes`);
+  if (data.length < 73)
+    throw new Error(`User account too small: ${data.length} bytes`);
   const view = data.subarray(8); // skip 8-byte Anchor discriminator
 
-  const userIdHash = view.subarray(0, 32);  // [0..32)
-  const roleU8 = view.readUInt8(32);        // byte 32
-  const walletRaw = view.subarray(33, 65);  // [33..65)
+  const userIdHash = view.subarray(0, 32); // [0..32)
+  const roleU8 = view.readUInt8(32); // byte 32
+  const walletRaw = view.subarray(33, 65); // [33..65)
 
   const wallet = new PublicKey(walletRaw);
   return {
@@ -212,7 +219,9 @@ function decodeUserAccount(data: Buffer) {
 /** Fetch + decode by PDA (string). */
 export async function fetchUserAccountByPda(userPdaStr: string) {
   const userPda = new PublicKey(userPdaStr);
-  const info: AccountInfo<Buffer> | null = await connection.getAccountInfo(userPda);
+  const info: AccountInfo<Buffer> | null = await connection.getAccountInfo(
+    userPda
+  );
   if (!info) return null;
 
   const decoded = decodeUserAccount(info.data);
@@ -228,4 +237,108 @@ export async function fetchUserAccountByPda(userPdaStr: string) {
 export async function fetchUserAccountByUserId(userId: string) {
   const userPda = await deriveUserPdaFromUserId(userId);
   return fetchUserAccountByPda(userPda.toBase58());
+}
+
+// Derive charger PDA (seeds: "charger", host_user_hash, charger_id_u64_le)
+export function deriveChargerPda(
+  hostUserHash32: Buffer,
+  chargerIdU64: bigint
+): PublicKey {
+  const programIdStr = process.env.TOPCHARGER_PROGRAM_ID;
+  if (!programIdStr) throw new Error("TOPCHARGER_PROGRAM_ID not set");
+  const programId = new PublicKey(programIdStr);
+  const idLe8 = Buffer.alloc(8);
+  idLe8.writeBigUInt64LE(chargerIdU64);
+
+  const [pda] = PublicKey.findProgramAddressSync(
+    [Buffer.from("charger"), hostUserHash32, idLe8],
+    programId
+  );
+  return pda;
+}
+
+/**
+ * Send `create_charger` instruction.
+ * On-chain schema:
+ *   args: user_id_hash [u8;32], charger_id u64(le), power_kw u16(le), supply_type u8, price u64(le)
+ *   accounts: charger(pda, writable, init), wallet, authority(signer), system_program
+ *
+ * MVP: we pass payer for both wallet & authority.
+ */
+export async function createChargerOnChain(args: {
+  backendUserId: string; // host's backend user id
+  chargerIdU64: bigint; // persisted in DB as chainId
+  powerKw: number; // from Charger.powerKw
+  supplyType: number; // 0=renewable, 1=non-renewable (your choice for MVP)
+  priceMicrousdPerKwh: bigint; // u64 microusd/kWh
+}) {
+  const {
+    backendUserId,
+    chargerIdU64,
+    powerKw,
+    supplyType,
+    priceMicrousdPerKwh,
+  } = args;
+
+  const programIdStr = process.env.TOPCHARGER_PROGRAM_ID;
+  if (!programIdStr) throw new Error("TOPCHARGER_PROGRAM_ID not set");
+
+  const userHash = sha256_32(backendUserId);
+  const chargerPda = deriveChargerPda(userHash, chargerIdU64);
+
+  // Discriminator for create_charger (from your IDL schema)
+  const discriminator = Buffer.from([241, 15, 76, 127, 48, 252, 134, 80]);
+
+  // Build args buffer
+  const idLe8 = Buffer.alloc(8);
+  idLe8.writeBigUInt64LE(chargerIdU64);
+
+  const powerLe2 = Buffer.alloc(2);
+  powerLe2.writeUInt16LE(Math.max(0, Math.min(65535, Math.round(powerKw))));
+
+  const priceLe8 = Buffer.alloc(8);
+  priceLe8.writeBigUInt64LE(priceMicrousdPerKwh);
+
+  const data = Buffer.concat([
+    discriminator, // 8
+    userHash, // 32
+    idLe8, // 8
+    powerLe2, // 2
+    Buffer.from([supplyType & 0xff]), // 1
+    priceLe8, // 8
+  ]);
+
+  // Accounts
+  const keys = [
+    { pubkey: chargerPda, isSigner: false, isWritable: true },
+    { pubkey: payer.publicKey, isSigner: false, isWritable: false }, // wallet (host wallet for MVP)
+    { pubkey: payer.publicKey, isSigner: true, isWritable: true }, // authority signer
+    { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+  ];
+
+  const ix = new TransactionInstruction({
+    programId: new PublicKey(programIdStr),
+    keys,
+    data,
+  });
+
+  const tx = new Transaction().add(ix);
+  tx.feePayer = payer.publicKey;
+
+  const latest = await connection.getLatestBlockhash();
+  tx.recentBlockhash = latest.blockhash;
+
+  // Sign & send
+  tx.sign(payer);
+  const sig = await connection.sendRawTransaction(tx.serialize());
+  await connection.confirmTransaction({
+    signature: sig,
+    blockhash: latest.blockhash,
+    lastValidBlockHeight: latest.lastValidBlockHeight,
+  });
+
+  return {
+    signature: sig,
+    chargerPda: chargerPda.toBase58(),
+  };
 }

--- a/apps/backend/src/lib/solana.ts
+++ b/apps/backend/src/lib/solana.ts
@@ -239,6 +239,16 @@ export async function fetchUserAccountByUserId(userId: string) {
   return fetchUserAccountByPda(userPda.toBase58());
 }
 
+// Deterministic u64 from a string
+export function hashToU64(s: string): bigint {
+  const h = crypto.createHash("sha256").update(s, "utf8").digest(); // 32 bytes
+  // take first 8 bytes little-endian as u64
+  return BigInt.asUintN(
+    64,
+    BigInt("0x" + Buffer.from(h.subarray(0, 8)).reverse().toString("hex"))
+  );
+}
+
 // Derive charger PDA (seeds: "charger", host_user_hash, charger_id_u64_le)
 export function deriveChargerPda(
   hostUserHash32: Buffer,


### PR DESCRIPTION
# PR: Implement Charger Creation Flow (Backend → Solana Devnet)

## Overview
This PR completes the **charger creation pipeline** from the backend to **Solana Devnet**, ensuring that newly registered chargers are persisted in the database and synchronized with on-chain state.  
It also includes **ESLint cleanup**, **Next.js param handling fixes**, and **database updates** for idempotency and field consistency.

---

## Changes

### 🚀 Feature: Charger Creation Flow
- Added `/api/hosts/chargers` endpoint:
  - Validates and creates a new charger in the PostgreSQL database.
  - Computes a deterministic `chainId` (via `hashToU64`).
  - Calls `createChargerOnChain()` to deploy the charger to **Solana Devnet**.
  - Updates the charger with `solanaChargerPda` and `solanaCreateTx` on success.
  - Returns Web2 fallback if on-chain sync fails (MVP-safe).

### 🧩 Database Modifications
- Added `naturalKey` (unique SHA-256 of host, name, and coordinates) to prevent duplicate charger inserts.
- Adjusted schema for optional Solana fields:
  - `solanaChargerPda`, `solanaCreateTx`
- Added default `powerKw` values per connector type.

### 🧹 ESLint & Type Fixes
- Removed all `any` types and enforced stricter typing in API routes.
- Fixed dynamic route params (`await ctx.params`) to comply with Next.js runtime rules.

### 🔧 Supporting Fixes
- Cleaned up `requireDriverContext` and `requireHostContext` to ensure correct type usage.
- Handled non-fatal Solana transaction errors gracefully.
- Improved `start` and `stop` session APIs (driver/charger exclusivity checks).

---

## Testing
```bash
# Create a new charger (host side)
curl -i -X POST http://localhost:3000/api/hosts/chargers \
  -H "Cookie: next-auth.session-token=<token>" \
  -H "Content-Type: application/json" \
  -d '{"name":"Garage A - Slot 2","latitude":44.7866,"longitude":20.4489,"pricePerKwh":0.25,"connector":"TYPE2","available":true}'

# Start a charging session (driver side)
curl -i -X POST http://localhost:3000/api/chargers/<chargerId>/start \
  -H "Cookie: next-auth.session-token=<token>"
