### PR TITLE
Darko/solana charging session

### DIFF
--- a/apps/backend/prisma/migrations/20251015171316_session_solana_match_pda/migration.sql
+++ b/apps/backend/prisma/migrations/20251015171316_session_solana_match_pda/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "ChargingSession" ADD COLUMN     "solanaMatchPda" TEXT;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -130,6 +130,8 @@ model ChargingSession {
   stoppedAt DateTime?
   energyKwh Float? // computed in STOP if you don’t have real meter
   costTotal Float? // computed in STOP
+  
+  solanaMatchPda       String?     // PDA of MatchAccount
 
   // Future blockchain hooks
   startTxSig String?

--- a/apps/backend/src/app/api/chargers/[chargerId]/start/route.ts
+++ b/apps/backend/src/app/api/chargers/[chargerId]/start/route.ts
@@ -10,11 +10,11 @@ export async function OPTIONS() {
 
 export async function POST(
   req: NextRequest,
-  context: { params: { chargerId: string } }
+  ctx: { params: Promise<{ chargerId: string }> } // params is a Promise
 ) {
   try {
     const { userId, driver } = await requireDriverContext(req);
-    const { chargerId } = context.params;
+     const { chargerId } = await ctx.params; // await before using params
 
     const charger = await prisma.charger.findUnique({
       where: { id: chargerId },

--- a/apps/backend/src/app/api/chargers/[chargerId]/start/route.ts
+++ b/apps/backend/src/app/api/chargers/[chargerId]/start/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from "next/server";
 import { prisma } from "@/lib/db";
 import { badRequest, forbidden, created, options } from "@/lib/http";
 import { requireDriverContext } from "@/lib/authz";
+import { sendReserveCharger } from "@/lib/solana";
 
 export async function OPTIONS() {
   return options();
@@ -51,6 +52,30 @@ export async function POST(
       });
       return s;
     });
+
+    // Best-effort Solana reserve
+    if (charger.solanaChargerPda) {
+      try {
+        const { signature, matchPda } = await sendReserveCharger({
+          backendUserId: userId,
+          chargerPda: charger.solanaChargerPda,
+        });
+        await prisma.chargingSession.update({
+          where: { id: session.id },
+          data: { startTxSig: signature, solanaMatchPda: matchPda },
+        });
+        return created({
+          session: {
+            ...session,
+            startTxSig: signature,
+            solanaMatchPda: matchPda,
+          },
+        });
+      } catch (e) {
+        console.error("reserve_charger failed:", e);
+        // do not fail the session creation
+      }
+    }
 
     return created({ session });
   } catch (e: unknown) {

--- a/apps/backend/src/app/api/sessions/[sessionId]/stop/route.ts
+++ b/apps/backend/src/app/api/sessions/[sessionId]/stop/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from "next/server";
 import { prisma } from "@/lib/db";
 import { badRequest, forbidden, ok, options } from "@/lib/http";
 import { requireDriverContext } from "@/lib/authz";
+import { sendConfirmCharge } from "@/lib/solana";
 
 export async function OPTIONS() {
   return options();
@@ -15,14 +16,19 @@ export async function POST(
     const { userId } = await requireDriverContext(req);
     const { sessionId } = params;
 
-    const session = await prisma.chargingSession.findUnique({ where: { id: sessionId } });
+    const session = await prisma.chargingSession.findUnique({
+      where: { id: sessionId },
+    });
     if (!session) return badRequest("Session not found");
 
     if (session.driverId !== userId) return forbidden("Not your session");
     if (session.status !== "ACTIVE") return badRequest("Session is not ACTIVE");
 
     const now = new Date();
-    const hours = Math.max(0, (now.getTime() - session.startedAt.getTime()) / 3_600_000);
+    const hours = Math.max(
+      0,
+      (now.getTime() - session.startedAt.getTime()) / 3_600_000
+    );
 
     const energyKwh = session.powerKwSnapshot * hours;
     const costTotal = energyKwh * session.pricePerKwhSnapshot;
@@ -44,10 +50,35 @@ export async function POST(
       return s;
     });
 
-    return ok({ session: updated });
+    // Best-effort Solana confirm
+    if (session.solanaMatchPda) {
+      try {
+        const { signature } = await sendConfirmCharge({
+          matchPda: session.solanaMatchPda,
+          wasCorrect: true, // MVP: always true
+        });
+        const s2 = await prisma.chargingSession.update({
+          where: { id: sessionId },
+          data: { stopTxSig: signature },
+        });
+        return ok({ session: s2 });
+      } catch (e) {
+        console.error("confirm_charge failed:", e);
+      }
+    }
+
+    return ok({
+      session: updated,
+      chainSync: "confirm_failed_or_missing_match_pda",
+    });
   } catch (e: unknown) {
     const status = (e as { status?: number } | null)?.status;
-    const message = e instanceof Error ? e.message : typeof e === "string" ? e : "Internal Server Error";
+    const message =
+      e instanceof Error
+        ? e.message
+        : typeof e === "string"
+        ? e
+        : "Internal Server Error";
     if (status === 403) return new Response(message, { status: 403 });
     console.error("POST /api/sessions/:id/stop failed:", e);
     return new Response("Internal Server Error", { status: 500 });

--- a/apps/backend/src/app/api/sessions/[sessionId]/stop/route.ts
+++ b/apps/backend/src/app/api/sessions/[sessionId]/stop/route.ts
@@ -10,11 +10,11 @@ export async function OPTIONS() {
 
 export async function POST(
   req: NextRequest,
-  { params }: { params: { sessionId: string } }
+  ctx: { params: Promise<{ sessionId: string }> }
 ) {
   try {
     const { userId } = await requireDriverContext(req);
-    const { sessionId } = params;
+    const { sessionId } = await ctx.params;
 
     const session = await prisma.chargingSession.findUnique({
       where: { id: sessionId },

--- a/apps/backend/src/lib/solana.ts
+++ b/apps/backend/src/lib/solana.ts
@@ -7,7 +7,7 @@ import {
   Transaction,
   SystemProgram,
   AccountInfo,
-  sendAndConfirmTransaction
+  sendAndConfirmTransaction,
 } from "@solana/web3.js";
 import * as anchor from "@coral-xyz/anchor";
 import type { Idl } from "@coral-xyz/anchor";
@@ -15,6 +15,10 @@ import bs58 from "bs58";
 import fs from "node:fs";
 import crypto from "node:crypto";
 import path from "node:path";
+
+// -------------------------
+// RPC + Payer
+// -------------------------
 
 export const connection = new Connection(
   process.env.SOLANA_RPC_URL || clusterApiUrl("devnet"),
@@ -44,25 +48,30 @@ export function clusterQueryParam(): "devnet" | "testnet" | "mainnet" {
   return "mainnet";
 }
 
+// -------------------------
+// Simple placeholder (sessions on-chain later)
+// -------------------------
+
 export type SolanaTxKind = "START" | "STOP";
 
 export type SolanaTxResult = {
-  signature: string; // tx sig
+  signature: string;
 };
 
 export async function sendSessionTx(
   _kind: SolanaTxKind,
   _args: { sessionId: string }
 ): Promise<SolanaTxResult> {
-  // mark as intentionally unused (avoids @typescript-eslint/no-unused-vars)
   void _kind;
   void _args;
-
-  // Placeholder for later: 1) build ix 2) send & confirm
   return { signature: "SIMULATED_SIG" };
 }
 
-// Map your app roles to a compact u8 value used by the program
+// -------------------------
+// Roles + hashing helpers
+// -------------------------
+
+// web2 -> on-chain role mapping
 function roleToU8(role: "HOST" | "DRIVER" | "UNSET" | "ADMIN"): number {
   switch (role) {
     case "HOST":
@@ -77,67 +86,106 @@ function roleToU8(role: "HOST" | "DRIVER" | "UNSET" | "ADMIN"): number {
   }
 }
 
-function hashUserIdTo32(userId: string): Buffer {
-  // Deterministic 32-byte hash
+function roleFromU8(n: number): "DRIVER" | "HOST" | "UNKNOWN" {
+  if (n === 0) return "DRIVER";
+  if (n === 1) return "HOST";
+  return "UNKNOWN";
+}
+
+function sha256_32(input: string): Buffer {
   return crypto
     .createHash("sha256")
-    .update(userId, "utf8")
+    .update(input, "utf8")
     .digest()
     .subarray(0, 32);
 }
 
-/** Extend the Anchor Idl with the discriminator present in built JSONs */
+export function hashToU64(s: string): bigint {
+  const h = crypto.createHash("sha256").update(s, "utf8").digest(); // 32 bytes
+  // take first 8 bytes little-endian as u64
+  return BigInt.asUintN(
+    64,
+    BigInt("0x" + Buffer.from(h.subarray(0, 8)).reverse().toString("hex"))
+  );
+}
+
+// -------------------------
+// IDL (single canonical path)
+// -------------------------
+
+const idlPath = path.join(
+  process.cwd(),
+  "target",
+  "idl",
+  "topcharger_program.json"
+);
+
+/** Anchor Idl extended with discriminator + optional program address fields that appear in JSON builds. */
 type IdlWithDisc = Idl & {
   metadata?: { address?: string };
   address?: string;
-  instructions: Array<{ name: string; discriminator: number[] }>;
+  instructions: Array<{ name: string; discriminator?: number[] }>;
 };
+
+function loadIdl(): IdlWithDisc {
+  const raw = fs.readFileSync(idlPath, "utf8");
+  const idl = JSON.parse(raw) as IdlWithDisc;
+  if (!idl?.instructions || !Array.isArray(idl.instructions)) {
+    throw new Error(`Invalid IDL: no instructions at ${idlPath}`);
+  }
+  return idl;
+}
+
+function discriminatorFor(ixName: string): Buffer {
+  const idl = loadIdl();
+  console.debug(`[solana] discriminatorFor("${ixName}") → reading IDL from:`, idlPath);
+  const ix = idl.instructions.find((i) => i.name === ixName);
+  if (!ix?.discriminator) {
+    throw new Error(
+      `IDL discriminator not found for "${ixName}" at ${idlPath}`
+    );
+  }
+  return Buffer.from(ix.discriminator);
+}
+
+function getProgramId(): PublicKey {
+  // Prefer env override; fall back to IDL-embedded address if present
+  const idl = loadIdl();
+  const fromEnv = process.env.TOPCHARGER_PROGRAM_ID;
+  const addr =
+    fromEnv ?? idl.metadata?.address ?? (idl.address as string | undefined);
+  if (!addr)
+    throw new Error("TOPCHARGER_PROGRAM_ID not set and IDL has no address");
+  return new PublicKey(addr);
+}
+
+// -------------------------
+// User register / fetch
+// -------------------------
 
 /**
  * Register a user on-chain (devnet) via Anchor-compatible flow.
- * Returns { signature, userPda }.
- * Idempotent at the PDA level (your program should no-op if already initialized).
+ * Returns { signature, userPda }. Idempotent at the PDA level.
  */
 export async function registerUserOnChain(
   userId: string,
   role: "HOST" | "DRIVER" | "UNSET" | "ADMIN"
-) {
-  // If the project is launched via `anchor test`/env, this binds to env provider.
+): Promise<{ signature: string; userPda: string }> {
+  // Use Anchor provider for signing (ANCHOR_WALLET / ANCHOR_PROVIDER_URL)
   anchor.setProvider(anchor.AnchorProvider.env());
   const provider = anchor.getProvider() as anchor.AnchorProvider;
   const wallet = provider.wallet as anchor.Wallet;
 
-  // Resolve Anchor workspace root and load IDL JSON (no require())
-  const probableProgramRoot = path.resolve(__dirname, "..", ".."); // adjust if needed
-  const anchorTomlPath = path.join(probableProgramRoot, "Anchor.toml");
-  if (fs.existsSync(anchorTomlPath)) process.chdir(probableProgramRoot);
-
-  const idlPath = path.join(
-    process.cwd(),
-    "target",
-    "idl",
-    "topcharger_program.json"
-  );
-  const idl = JSON.parse(fs.readFileSync(idlPath, "utf8")) as IdlWithDisc;
-
-  const programId = new PublicKey(
-    process.env.TOPCHARGER_PROGRAM_ID ??
-      idl.metadata?.address ??
-      (idl.address as string)
-  );
+  const programId = getProgramId(); // unified
 
   const roleU8 = roleToU8(role);
-  const userHash = hashUserIdTo32(userId);
-
+  const userHash = sha256_32(userId);
   const [userPda] = PublicKey.findProgramAddressSync(
     [Buffer.from("user"), userHash],
     programId
   );
 
-  const ixDesc = idl.instructions.find((ix) => ix.name === "register_user");
-  if (!ixDesc) throw new Error("register_user instruction not found in IDL");
-
-  const discriminator = Buffer.from(ixDesc.discriminator);
+  const discriminator = discriminatorFor("register_user");
   const argsBuf = Buffer.concat([Buffer.from([roleU8 & 0xff]), userHash]);
   const data = Buffer.concat([discriminator, argsBuf]);
 
@@ -149,7 +197,6 @@ export async function registerUserOnChain(
   ];
 
   const ix = new TransactionInstruction({ programId, keys, data });
-
   const tx = new Transaction().add(ix);
   tx.feePayer = wallet.publicKey;
 
@@ -164,31 +211,14 @@ export async function registerUserOnChain(
     lastValidBlockHeight: latest.lastValidBlockHeight,
   });
 
-  return { signature: sig as string, userPda: userPda.toBase58() };
-}
-// --- Role mapping aligned to on-chain: 0 = DRIVER, 1 = HOST ---
-function roleFromU8(n: number): "DRIVER" | "HOST" | "UNKNOWN" {
-  if (n === 0) return "DRIVER";
-  if (n === 1) return "HOST";
-  return "UNKNOWN";
-}
-
-function sha256_32(userId: string): Buffer {
-  return crypto
-    .createHash("sha256")
-    .update(userId, "utf8")
-    .digest()
-    .subarray(0, 32);
+  return { signature: sig, userPda: userPda.toBase58() };
 }
 
 /** Derive the User PDA from backend userId (no IDL needed). */
 export async function deriveUserPdaFromUserId(
   userId: string
 ): Promise<PublicKey> {
-  const programIdStr = process.env.TOPCHARGER_PROGRAM_ID;
-  if (!programIdStr) throw new Error("TOPCHARGER_PROGRAM_ID not set");
-  const programId = new PublicKey(programIdStr);
-
+  const programId = getProgramId();
   const userHash = sha256_32(userId);
   const [userPda] = PublicKey.findProgramAddressSync(
     [Buffer.from("user"), userHash],
@@ -197,7 +227,7 @@ export async function deriveUserPdaFromUserId(
   return userPda;
 }
 
-/** Manual decode of the on-chain User account without IDL (Anchor discriminator + struct). */
+/** Manual decode of the on-chain User account without full IDL decode. */
 function decodeUserAccount(data: Buffer) {
   // Expect 8 (disc) + 32 (hash) + 1 (role) + 32 (wallet) = 73 bytes
   if (data.length < 73)
@@ -240,27 +270,18 @@ export async function fetchUserAccountByUserId(userId: string) {
   return fetchUserAccountByPda(userPda.toBase58());
 }
 
-// Deterministic u64 from a string
-export function hashToU64(s: string): bigint {
-  const h = crypto.createHash("sha256").update(s, "utf8").digest(); // 32 bytes
-  // take first 8 bytes little-endian as u64
-  return BigInt.asUintN(
-    64,
-    BigInt("0x" + Buffer.from(h.subarray(0, 8)).reverse().toString("hex"))
-  );
-}
+// -------------------------
+// Charger helpers + on-chain create
+// -------------------------
 
 // Derive charger PDA (seeds: "charger", host_user_hash, charger_id_u64_le)
 export function deriveChargerPda(
   hostUserHash32: Buffer,
   chargerIdU64: bigint
 ): PublicKey {
-  const programIdStr = process.env.TOPCHARGER_PROGRAM_ID;
-  if (!programIdStr) throw new Error("TOPCHARGER_PROGRAM_ID not set");
-  const programId = new PublicKey(programIdStr);
+  const programId = getProgramId();
   const idLe8 = Buffer.alloc(8);
   idLe8.writeBigUInt64LE(chargerIdU64);
-
   const [pda] = PublicKey.findProgramAddressSync(
     [Buffer.from("charger"), hostUserHash32, idLe8],
     programId
@@ -274,15 +295,15 @@ export function deriveChargerPda(
  *   args: user_id_hash [u8;32], charger_id u64(le), power_kw u16(le), supply_type u8, price u64(le)
  *   accounts: charger(pda, writable, init), wallet, authority(signer), system_program
  *
- * MVP: we pass payer for both wallet & authority.
+ * MVP: payer is both wallet & authority.
  */
 export async function createChargerOnChain(args: {
   backendUserId: string; // host's backend user id
   chargerIdU64: bigint; // persisted in DB as chainId
   powerKw: number; // from Charger.powerKw
-  supplyType: number; // 0=renewable, 1=non-renewable (your choice for MVP)
+  supplyType: number; // 0=renewable, 1=non-renewable (your choice)
   priceMicrousdPerKwh: bigint; // u64 microusd/kWh
-}) {
+}): Promise<{ signature: string; chargerPda: string }> {
   const {
     backendUserId,
     chargerIdU64,
@@ -291,14 +312,13 @@ export async function createChargerOnChain(args: {
     priceMicrousdPerKwh,
   } = args;
 
-  const programIdStr = process.env.TOPCHARGER_PROGRAM_ID;
-  if (!programIdStr) throw new Error("TOPCHARGER_PROGRAM_ID not set");
+  const programId = getProgramId();
 
   const userHash = sha256_32(backendUserId);
   const chargerPda = deriveChargerPda(userHash, chargerIdU64);
 
-  // Discriminator for create_charger (from your IDL schema)
-  const discriminator = Buffer.from([241, 15, 76, 127, 48, 252, 134, 80]);
+  // Discriminator from IDL (no hardcode)
+  const discriminator = discriminatorFor("create_charger");
 
   // Build args buffer
   const idLe8 = Buffer.alloc(8);
@@ -327,11 +347,7 @@ export async function createChargerOnChain(args: {
     { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
   ];
 
-  const ix = new TransactionInstruction({
-    programId: new PublicKey(programIdStr),
-    keys,
-    data,
-  });
+  const ix = new TransactionInstruction({ programId, keys, data });
 
   const tx = new Transaction().add(ix);
   tx.feePayer = payer.publicKey;
@@ -341,73 +357,44 @@ export async function createChargerOnChain(args: {
 
   // Sign & send
   tx.sign(payer);
-  const sig = await connection.sendRawTransaction(tx.serialize());
+  const signature = await connection.sendRawTransaction(tx.serialize());
   await connection.confirmTransaction({
-    signature: sig,
+    signature,
     blockhash: latest.blockhash,
     lastValidBlockHeight: latest.lastValidBlockHeight,
   });
 
-  return {
-    signature: sig,
-    chargerPda: chargerPda.toBase58(),
-  };
+  return { signature, chargerPda: chargerPda.toBase58() };
 }
 
-function getProgramId(): PublicKey {
-  const pid = process.env.TOPCHARGER_PROGRAM_ID;
-  if (!pid) throw new Error("TOPCHARGER_PROGRAM_ID not set");
-  return new PublicKey(pid);
+// -------------------------
+// Match (reserve/confirm) pipeline
+// -------------------------
+
+function programId(): PublicKey {
+  return getProgramId();
 }
 
-type IdlInstruction = {
-  name: string;
-  discriminator?: number[]; // Anchor JSON IDL contains discriminator in recent versions
-};
-
-type TopchargerIdl = {
-  instructions: IdlInstruction[];
-};
-
-function loadIdl(): TopchargerIdl {
-  const idlPath =
-    process.env.TOPCHARGER_IDL_PATH ??
-    path.join(process.cwd(), "apps", "backend", "target", "idl", "topcharger_program.json");
-  const raw = fs.readFileSync(idlPath, "utf8");
-  const json = JSON.parse(raw) as unknown;
-  // minimal runtime validation
-  const asIdl = json as Partial<TopchargerIdl>;
-  if (!asIdl || !Array.isArray(asIdl.instructions)) {
-    throw new Error("Invalid IDL: missing instructions");
-  }
-  return asIdl as TopchargerIdl;
-}
-
-function discriminatorFor(ixName: string): Buffer {
-  const idl = loadIdl();
-  const ix = idl.instructions.find((i) => i.name === ixName);
-  if (!ix?.discriminator) throw new Error(`IDL discriminator not found for ${ixName}`);
-  return Buffer.from(ix.discriminator);
-}
-
-export async function deriveMatchPda(chargerPubkey: PublicKey): Promise<PublicKey> {
-  const programId = getProgramId();
+export async function deriveMatchPda(
+  chargerPubkey: PublicKey
+): Promise<PublicKey> {
+  const pid = programId();
   const [pda] = PublicKey.findProgramAddressSync(
     [Buffer.from("match"), chargerPubkey.toBuffer()],
-    programId
+    pid
   );
   return pda;
 }
 
 export type ReserveChargerArgs = {
-  backendUserId: string;   // driver backend id -> hashed on-chain
-  chargerPda: string;      // base58 PDA of ChargerAccount (must exist)
+  backendUserId: string; // driver backend id -> hashed on-chain
+  chargerPda: string; // base58 PDA of ChargerAccount (must exist)
 };
 
 export async function sendReserveCharger(
   args: ReserveChargerArgs
 ): Promise<{ signature: string; matchPda: string }> {
-  const programId = getProgramId();
+  const pid = programId();
   const charger = new PublicKey(args.chargerPda);
   const matchPda = await deriveMatchPda(charger);
 
@@ -422,7 +409,7 @@ export async function sendReserveCharger(
     { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
   ];
 
-  const ix = new TransactionInstruction({ programId, keys, data });
+  const ix = new TransactionInstruction({ programId: pid, keys, data });
   const tx = new Transaction().add(ix);
   const signature = await sendAndConfirmTransaction(connection, tx, [payer], {
     commitment: "confirmed",
@@ -432,14 +419,14 @@ export async function sendReserveCharger(
 }
 
 export type ConfirmChargeArgs = {
-  matchPda: string;     // base58 PDA of MatchAccount
-  wasCorrect: boolean;  // MVP: true
+  matchPda: string; // base58 PDA of MatchAccount
+  wasCorrect: boolean;
 };
 
 export async function sendConfirmCharge(
   args: ConfirmChargeArgs
 ): Promise<{ signature: string }> {
-  const programId = getProgramId();
+  const pid = programId();
   const matchPubkey = new PublicKey(args.matchPda);
 
   const disc = discriminatorFor("confirm_charge");
@@ -447,7 +434,7 @@ export async function sendConfirmCharge(
 
   const keys = [{ pubkey: matchPubkey, isSigner: false, isWritable: true }];
 
-  const ix = new TransactionInstruction({ programId, keys, data });
+  const ix = new TransactionInstruction({ programId: pid, keys, data });
   const tx = new Transaction().add(ix);
   const signature = await sendAndConfirmTransaction(connection, tx, [payer], {
     commitment: "confirmed",


### PR DESCRIPTION
# PR: Integrate Solana Charging Session Flow (Reserve & Confirm)

## Overview
This PR implements the **charging session pipeline** connecting the backend with **Solana Devnet**.  
When a driver starts or stops a session, the backend now triggers the on-chain instructions `reserve_charger` and `confirm_charge` in the `topcharger_program`.  
This closes the loop between **Web2 session state** and **Web3 on-chain state** for chargers and sessions.

---

## Changes

### ⚡ Feature: Solana Charging Session Flow
- `sendReserveCharger()` is called during  
  `POST /api/chargers/[chargerId]/start` → allocates the charger on-chain.
- `sendConfirmCharge()` is called during  
  `POST /api/sessions/[sessionId]/stop` → finalizes the match on-chain.
- Deterministic PDAs are used:
  - `deriveMatchPda()` for `MatchAccount`
  - Existing `deriveChargerPda()` for `ChargerAccount`
- `discriminatorFor()` reads instruction discriminators from the IDL.

---

### 🧩 IDL & Program Handling
- Unified IDL loading path to:
`target/idl/topcharger_program.json`
- Added temporary debug log in `discriminatorFor()` to print the active IDL path (useful during dev).

---

### 🧰 Backend Updates
- Start/Stop session routes updated to trigger Solana transactions **after DB updates**.
- Strong typing for Solana helpers (`ReserveChargerArgs`, `ConfirmChargeArgs`).
- On-chain failures are **non-fatal for MVP** (API still succeeds; on-chain sync can be retried later).

---

### 🧹 Cleanup & Fixes
- Removed `any` usage and fixed ESLint issues.
- Standardized Next.js `NextRequest` param handling and error paths.
- Improved transaction confirmation flow against **Devnet**.

---

## Testing

### 🚗 Start a charging session (driver)
```bash
curl -i -X POST http://localhost:3000/api/chargers/<chargerId>/start \
-H "Cookie: next-auth.session-token=<token>"
```

### 🛑 Stop a charging session (driver)
```bash
curl -i -X POST http://localhost:3000/api/sessions/<sessionId>/stop \
  -H "Cookie: next-auth.session-token=<token>"
```
