### PR TITLE
Darko/solana match account seed

### DIFF
--- a/apps/backend/src/app/api/auth/[...nextauth]/route.ts
+++ b/apps/backend/src/app/api/auth/[...nextauth]/route.ts
@@ -43,7 +43,7 @@ export const authOptions: NextAuthOptions = {
       }
       return session;
     },
-    async redirect({ url, baseUrl }) {
+    async redirect({ url }) {
       if (url.startsWith(FRONTEND)) return url;
       return `${FRONTEND}/auth/callback`;
     },

--- a/apps/backend/src/app/auth/signin/page.tsx
+++ b/apps/backend/src/app/auth/signin/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { getProviders, signIn } from "next-auth/react";
+import { signIn } from "next-auth/react";
 
 export default function SignInPage() {
     useEffect(() => {


### PR DESCRIPTION
# PR: Update Solana Session Flow (match_id Integration)

## Overview
This PR aligns the backend with the **updated on-chain IDL**, where  
`match_account` PDA seeds are now defined as `["match", match_id]`.  
The backend now derives and passes `match_id` deterministically from the session ID to ensure unique and traceable session allocations.

---

## Changes

### 🧩 IDL & PDA Updates
- Updated **`sendReserveCharger()`**:
  - Generates 32-byte `match_id` using SHA-256 of backend `session.id`.
  - Derives `match_account` PDA via `["match", match_id]` seed.
  - Adjusted instruction data layout to match new IDL order:
    - `discriminator + match_id(32) + driver_user_hash(32)`
- Updated **`sendConfirmCharge()`**:
  - Includes both `match_account` and `charger` as required by the new IDL schema.
  - Executes `confirm_charge(was_correct)` using consistent PDA derivation.

### ⚡ Backend Integration
- In `/api/chargers/[chargerId]/start`:
  - Added `hash32(session.id)` → `matchId32` for deterministic on-chain seed derivation.
  - Calls `sendReserveCharger({ backendUserId, chargerPda, matchId32 })`.
- In `/api/sessions/[sessionId]/stop`:
  - Calls `sendConfirmCharge({ matchPda, chargerPda, wasCorrect: true })`.

### 🔧 Utilities
- Added helper `hash32(input: string)` → returns 32-byte Buffer (used for match_id derivation).
- Added `deriveMatchPdaFromMatchId(matchId32)` → PDA derivation consistent with on-chain seeds.
- Unified IDL path resolution:
  - Always reads from `apps/backend/target/idl/topcharger_program.json`.

---

## Result
Each charging session now produces a **unique on-chain match account** tied to its backend session, ensuring one-to-one correspondence between Web2 and Web3 states.
